### PR TITLE
Added automx-text to setup.py so it will be installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,6 @@ setup(name='automx',
       packages=['automx'],
       package_dir={'': 'src'},
       data_files=[('/etc', ['src/conf/automx.conf'])],
+      scripts=['src/automx-test'],
       )
 


### PR DESCRIPTION
I have packaged automx for Debian. One of my users complained, that the automx-test script is not included (http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=731233) in the package. I fixed this with adding 'scripts=' to setup.py.
