### PR TITLE
* fix autodiscover bug

### DIFF
--- a/src/automx_wsgi.py
+++ b/src/automx_wsgi.py
@@ -176,8 +176,7 @@ def application(environ, start_response):
     
         elif request_method == "GET":
             # FIXME: maybe we need to catch AutoDiscover GET-REDIRECT requests
-            if "autodiscover" in (environ["HTTP_HOST"],
-                                  environ["REQUEST_URI"].lower()):
+            if any("autodiscover" in s for s in (environ["HTTP_HOST"], environ["REQUEST_URI"].lower())):
                 process = False
                 status = STAT_ERR
             


### PR DESCRIPTION
Autodiscover does not work.
I found the Problem the check in line 179 in automx_wsgi.py does not work
```
if "autodiscover" in (environ["HTTP_HOST"], environ["REQUEST_URI"].lower()):
```
The solution is:
```
if any("autodiscover" in s for s in (environ["HTTP_HOST"], environ["REQUEST_URI"].lower())
```