### PR TITLE
Add cal/carddav support as well as Open-Xchange detection

### DIFF
--- a/src/automx/config.py
+++ b/src/automx/config.py
@@ -72,47 +72,47 @@ class Config(configparser.RawConfigParser):
     independend from the view. It may query different backends to gather all
     required information needed to generate XML output later on in the view
     class.
-    
+
     It uses a OrderdDict to guarentee the correct service order that is needed
     in the XML output. This said means that it is a difference, if a service
     like IMAP is configured before POP3 or upside down, because a MUA follows
     this order.
-    
-    The class currently support smtp, pop and imap services.
-    
+
+    The class currently support smtp, pop, imap, carddav, caldav and ox services.
+
     The class currently supports the following backends:
-    
+
     -> global - This backend tells automx to use the global section
-    
+
     -> static - all kind of service information that can be sent directly to
                 the MUA
-                
+
     -> filter - This backend can execute commands and collects results from
                 stdout. The result may be "", which means we skip further
                 searching. It may return data, which should point to a section
                 that we try to follow.
-                
+
     -> ldap   - Read all kind of information from LDAP servers. The result
                 attributes are stored in an internal dictionary and if options
                 later on in this backend section (is read as static backend)
                 do contain variables in the form ${attributename}, these are
                 expanded to the collected data.
-                
+
     -> sql    - Read all kind of information from SQL servers. The result
                 attributes are stored in an internal dictionary. See ldpa
-                
+
     -> script - Execute a script and split a result into attributes, which are
                 stored in an internal dictionary, See ldap
-                
+
     -> file   - Provide static files. If present, all collected data are
                 discarded and only the static file is sent to the remote
                 client. This may change in future releases.
-    
+
     Note: There may exist a DEFAULT section that is appended to _all_ sections
     in the configuration file. That said you can do really complex
     configurations that on the other hand make life easier. This section also
     may contain variables, which, if found in the vars-dictionary, are used.
-    
+
     """
 
     def __init__(self, environ):
@@ -259,6 +259,12 @@ class Config(configparser.RawConfigParser):
                         service = self.__service(section, "imap")
                     elif opt == "pop":
                         service = self.__service(section, "pop")
+                    elif opt == "carddav":
+                        service = self.__service(section, "carddav")
+                    elif opt == "caldav":
+                        service = self.__service(section, "caldav")
+                    elif opt == "ox":
+                        service = self.__service(section, "ox")
                     elif opt == "sign_mobileconfig":
                         try:
                             settings[opt] = self.getboolean(section, opt)
@@ -274,7 +280,7 @@ class Config(configparser.RawConfigParser):
                     else:
                         pass
 
-                    if opt in ("smtp", "imap", "pop"):
+                    if opt in ("smtp", "imap", "pop", "caldav", "carddav", "ox"):
                         if backend == "static_append":
                             if opt in settings:
                                 if self.debug:
@@ -650,7 +656,7 @@ class Config(configparser.RawConfigParser):
 
                             got_data = True
 
-                            # we replace our search_domain 
+                            # we replace our search_domain
                             self.__search_domain = special_opt
                             self.__emailaddress = new_emailaddress
 

--- a/src/automx/view.py
+++ b/src/automx/view.py
@@ -49,7 +49,7 @@ class View(object):
     is used in Mozilla Thunderbird and several other open-source MUAs. It also
     supports .mobileconfig profile support as found on iOS devices. These
     profiles can also be used on Mac OS X Mail.app
-        
+
     """
 
     def __init__(self, model, schema, subschema):
@@ -133,7 +133,7 @@ class View(object):
                     raise Exception("Missing attribute <action>")
 
                 for key, value in self.__model.domain.items():
-                    if key in ("smtp", "imap", "pop"):
+                    if key in ("smtp", "imap", "pop", "caldav", "carddav", "ox"):
                         if len(value) != 0:
                             protocol = etree.SubElement(account, "Protocol")
                             self.__service(key, protocol)
@@ -305,6 +305,12 @@ class View(object):
                 s_type = service.upper()
             elif service in "pop":
                 s_type = "POP3"
+            elif service in "caldav":
+                s_type = "CalDAV"
+            elif service in "carddav":
+                s_type = "CardDAV"
+            elif service in "ox":
+                s_type = "X-OX-APPSUITE"
 
             c.text = s_type
 
@@ -464,19 +470,19 @@ class View(object):
             if service + "_server" in elem:
                 if service in ("imap", "pop"):
                     proto["in_server"] = elem[service + "_server"]
-                else:
+                elif service == "smtp":
                     proto["out_server"] = elem[service + "_server"]
 
             if service + "_port" in elem:
                 if service in ("imap", "pop"):
                     proto["in_port"] = int(elem[service + "_port"])
-                else:
+                elif service == "smtp":
                     proto["out_port"] = int(elem[service + "_port"])
 
             if service + "_auth_identity" in elem:
                 if service in ("imap", "pop"):
                     proto["in_username"] = elem[service + "_auth_identity"]
-                else:
+                elif service == "smtp":
                     proto["out_username"] = elem[service + "_auth_identity"]
 
             if service + "_auth" in elem:
@@ -504,7 +510,7 @@ class View(object):
 
                 if service in ("imap", "pop"):
                     proto["in_auth"] = result
-                else:
+                elif service == "smtp":
                     proto["out_auth"] = result
 
             if service + "_encryption" in elem:
@@ -513,12 +519,12 @@ class View(object):
                 if value in ("ssl", "starttls"):
                     if service in ("imap", "pop"):
                         proto["in_encryption"] = True
-                    else:
+                    elif service == "smtp":
                         proto["out_encryption"] = True
                 else:
                     if service in ("imap", "pop"):
                         proto["in_encryption"] = False
-                    else:
+                    elif service == "smtp":
                         proto["out_encryption"] = False
 
     def render(self):
@@ -584,7 +590,7 @@ class View(object):
 
                     sign_cert = self.__model.domain["sign_cert"]
                     sign_key = self.__model.domain["sign_key"]
-                    
+
                     if "sign_more_certs" in self.__model.domain:
                         extra = " -certfile " + self.__model.domain[
                             "sign_more_certs"]


### PR DESCRIPTION
Add caldav and carddav detection support which seems to be standardized services for autodiscover protocol. Tested successfully with eMClient.

Also add Open-Xchange Server detection to autodiscover as X-OX-APPSUITE service.

With those changes applied we can fully support Open-Xchange and eMClient for OX.

(the patch contains a few whitespaces fixes automatically performed by atom)