### PR TITLE
Change http links to https

### DIFF
--- a/src/html/index.html.de
+++ b/src/html/index.html.de
@@ -42,11 +42,11 @@
   </div>
 
   <div id="footer-desktop" class="hide-for-small">
-    <a class="right automx-powered" href="http://automx.org" target="_blank">Powered by <img src="img/automx-banner.png" width="126" height="20" alt="automx banner" /></a>
+    <a class="right automx-powered" href="https://automx.org" target="_blank">Powered by <img src="img/automx-banner.png" width="126" height="20" alt="automx banner" /></a>
   </div>
   <div id="footer-mobile" class="show-for-small row">
     <div class="small-12 columns">
-      <a class="right automx-powered" href="http://automx.org" target="_blank">Powered by <img src="img/automx-banner.png" width="126" height="20" alt="automx banner" /></a>
+      <a class="right automx-powered" href="https://automx.org" target="_blank">Powered by <img src="img/automx-banner.png" width="126" height="20" alt="automx banner" /></a>
     </div>
   </div>
 

--- a/src/html/index.html.en
+++ b/src/html/index.html.en
@@ -43,11 +43,11 @@
   </div>
 
   <div id="footer-desktop" class="hide-for-small">
-    <a class="right automx-powered" href="http://automx.org" target="_blank">Powered by <img src="img/automx-banner.png" width="126" height="20" alt="automx banner" /></a>
+    <a class="right automx-powered" href="https://automx.org" target="_blank">Powered by <img src="img/automx-banner.png" width="126" height="20" alt="automx banner" /></a>
   </div>
   <div id="footer-mobile" class="show-for-small row">
     <div class="small-12 columns">
-      <a class="right automx-powered" href="http://automx.org" target="_blank">Powered by <img src="img/automx-banner.png" width="126" height="20" alt="automx banner" /></a>
+      <a class="right automx-powered" href="https://automx.org" target="_blank">Powered by <img src="img/automx-banner.png" width="126" height="20" alt="automx banner" /></a>
     </div>
   </div>
 


### PR DESCRIPTION
The webpage is https only anyway and http should be considered deprecated, so avoid an unnecessary redirect by making the links https.