### PR TITLE
Convert variable expansion result from bytearray to string

### DIFF
--- a/src/automx/config.py
+++ b/src/automx/config.py
@@ -854,7 +854,7 @@ class Config(configparser.RawConfigParser):
 
                             return dcs[-i]
 
-                return _result
+                return _result.decode('utf-8')
             else:
                 # we always must expand variables. Even if it is the empty
                 # string


### PR DESCRIPTION
I got errors of the form

2018-11-12 11:52:27,682 ERROR: data.configure(): sequence item 0: expected str instance, bytes found

when running automx with python 3 and the script backend.

Debugging it seems the origin of that type error was the result of the "repl" function in config.py. Adding a .decode('utf-8') fixes it.

Please note that I have not tested this code with Python 2, if support for that is still desired then this should be tested.